### PR TITLE
fix(business-service): use endpoint prefix for pending invitations API

### DIFF
--- a/src/services/business.service.ts
+++ b/src/services/business.service.ts
@@ -222,7 +222,7 @@ class BusinessService extends APIBase {
   async listPendingInvitationsForUser(): Promise<PendingInvitationsResponse> {
     try {
       const response: AxiosResponse<PendingInvitationsResponse> = await this.get<PendingInvitationsResponse>(
-        'team/invitations/pending'
+        `${this.endpoint}/team/invitations/pending`
       )
       return response.data
     } catch (error) {


### PR DESCRIPTION
Ensure API requests use the correct endpoint by including the base URL prefix. This prevents potential routing issues when the service is deployed in different environments.